### PR TITLE
fix invalid access when unexpected client connects

### DIFF
--- a/bot2-lcm-utils/src/tunnel/lcm_tunnel.cpp
+++ b/bot2-lcm-utils/src/tunnel/lcm_tunnel.cpp
@@ -56,7 +56,7 @@ LcmTunnel::LcmTunnel(bool verbose, const char *lcm_channel) :
   verbose(verbose), regex(NULL), buf_sz(65536), buf((char*) calloc(65536, sizeof(char))), channel_sz(65536), channel(
       (char*) calloc(65536, sizeof(char))), recFlags_sz(1024), recFlags((char*) calloc(1024, sizeof(char))), ldpc_dec(
       NULL), udp_fd(-1), server_udp_port(-1), udp_send_seqno(0), stopSendThread(false), bytesInQueue(0), cur_seqno(0),
-      errorStartTime(-1), numSuccessful(0), lastErrorPrintTime(-1), subscription(NULL)
+      errorStartTime(-1), numSuccessful(0), lastErrorPrintTime(-1), subscription(NULL), server_params(NULL), tunnel_params(NULL)
 {
   //allocate and initialize things
 
@@ -661,6 +661,9 @@ gpointer LcmTunnel::sendThreadFunc(gpointer user_data)
   while (!self->stopSendThread) {
     if (self->sendQueue.empty()) {
       g_cond_wait(self->sendQueueCond, self->sendQueueLock);
+      if (self->stopSendThread){
+        break;
+      }
       nextFlushTime = _timestamp_now() + self->tunnel_params->max_delay_ms * 1000;
       continue;
     }


### PR DESCRIPTION
when tunnel server is up, if any unexpected incoming tcp connections, `tunnel_params` may be not valid, so lcm-tunnel may crash.